### PR TITLE
Fixed warning about redundancy. clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ static DEVICE: Lazy<Mutex<VirtualDevice>> = Lazy::new(|| {
                     RelativeAxisType::REL_Y,
                     RelativeAxisType::REL_WHEEL,
                 ]
-                .into_iter(),
             ))
             .unwrap()
             .with_absolute_axis(&UinputAbsSetup::new(


### PR DESCRIPTION
Fixed Redundant Conversion:

The array slice automatically converts to an iterator, so the call to .into_iter() is unnecessary.