### PR TITLE
Future-proof casting bool to i32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub extern "C" fn XTestFakeKeyEvent(
     #[cfg(debug_assertions)]
     println!("emitting keycode {key:?}");
 
-    dev.emit(&[InputEvent::new_now(EventType::KEY, key.0, is_press as i32)])
+    dev.emit(&[InputEvent::new_now(EventType::KEY, key.0, i32::from(is_press))])
         .unwrap();
     1
 }
@@ -140,7 +140,7 @@ pub extern "C" fn XTestFakeButtonEvent(
         }
     };
 
-    dev.emit(&[InputEvent::new_now(EventType::KEY, key.0, is_press as i32)])
+    dev.emit(&[InputEvent::new_now(EventType::KEY, key.0, i32::from(is_press))])
         .unwrap();
     1
 }


### PR DESCRIPTION
If the type of is_press changes in the future, the as cast may not handle the conversion safely and could introduce silent bugs.

i32::from: Using i32::from ensures that the conversion is handled safely and explicitly, making it more robust against future changes.