### PR TITLE
refactor: resolve strict clippy diagnostics across lib and wayland modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use evdev::{
     uinput::VirtualDevice, AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent, KeyCode,
     RelativeAxisCode, UinputAbsSetup,
 };
-use once_cell::sync::Lazy;
 use std::ffi::{c_int, c_uint, c_ulong};
 use std::sync::Mutex;
 
@@ -19,7 +18,7 @@ pub struct Display {
     _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
-static DEVICE: Lazy<Mutex<VirtualDevice>> = Lazy::new(|| {
+static DEVICE: std::sync::LazyLock<Mutex<VirtualDevice>> = std::sync::LazyLock::new(|| {
     let size = get_axes_range();
     Mutex::new(
         VirtualDevice::builder()
@@ -79,10 +78,10 @@ pub extern "C" fn XTestFakeKeyEvent(
     dev.emit(&[InputEvent::new_now(
         EventType::KEY.0,
         key.0,
-        is_press as i32,
+        i32::from(is_press),
     )])
     .unwrap();
-    1
+    return 1;
 }
 
 #[repr(u8)]
@@ -99,7 +98,7 @@ enum MouseButtons {
 impl TryFrom<u32> for MouseButtons {
     type Error = u32;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        use MouseButtons::*;
+        use MouseButtons::{LeftClick, MiddleClick, RightClick, ScrollUp, ScrollDown, Side, Extra};
         match value {
             1 => Ok(LeftClick),
             2 => Ok(MiddleClick),
@@ -158,10 +157,10 @@ pub extern "C" fn XTestFakeButtonEvent(
     dev.emit(&[InputEvent::new_now(
         EventType::KEY.0,
         key.0,
-        is_press as i32,
+        i32::from(is_press),
     )])
     .unwrap();
-    1
+    return 1;
 }
 
 #[no_mangle]
@@ -177,7 +176,7 @@ pub extern "C" fn XTestFakeRelativeMotionEvent(
         InputEvent::new_now(EventType::RELATIVE.0, RelativeAxisCode::REL_Y.0, y),
     ];
     dev.emit(&events).unwrap();
-    1
+    return 1;
 }
 
 #[no_mangle]
@@ -194,5 +193,5 @@ pub extern "C" fn XTestFakeMotionEvent(
         InputEvent::new_now(EventType::ABSOLUTE.0, AbsoluteAxisCode::ABS_Y.0, y),
     ];
     dev.emit(&events).unwrap();
-    1
+    return 1;
 }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -32,7 +32,7 @@ pub fn get_axes_range() -> DisplaySize {
     let mut data = OutputData::default();
     queue.roundtrip(&mut data).unwrap();
 
-    for output in data.wl_outputs.iter() {
+    for output in &data.wl_outputs {
         data.output_man
             .as_ref()
             .unwrap()
@@ -47,9 +47,9 @@ impl Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for OutputData {
         state: &mut Self,
         _: &zxdg_output_v1::ZxdgOutputV1,
         event: zxdg_output_v1::Event,
-        _: &(),
+        (): &(),
         _: &Connection,
-        _: &QueueHandle<OutputData>,
+        _: &QueueHandle<Self>,
     ) {
         if let zxdg_output_v1::Event::LogicalSize { width, height } = event {
             println!("detected display with width {width} and height {height}");
@@ -66,9 +66,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for OutputData {
         state: &mut Self,
         registry: &wl_registry::WlRegistry,
         event: wl_registry::Event,
-        _: &(),
+        (): &(),
         _: &Connection,
-        handle: &QueueHandle<OutputData>,
+        handle: &QueueHandle<Self>,
     ) {
         if let wl_registry::Event::Global {
             name,


### PR DESCRIPTION
This pull request primarily refactors code in `src/lib.rs` and `src/wayland.rs` to improve code style, update usage of synchronization primitives, and clarify type conversions. The main changes include replacing `once_cell::sync::Lazy` with `std::sync::LazyLock`, simplifying type conversions, and making minor improvements to iterator and trait usage.

**Refactoring and Modernization:**

* Replaced `once_cell::sync::Lazy` with `std::sync::LazyLock` for the static `DEVICE` initialization in `src/lib.rs`, aligning with modern Rust standard library features.
* Updated the conversion of boolean values to integers in several FFI functions to use `i32::from(is_press)` instead of `is_press as i32`, making the conversion explicit and idiomatic. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L82-R84) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L161-R163) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L180-R179) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L197-R196)

**Code Style and Clarity:**

* Changed `for output in data.wl_outputs.iter()` to `for output in &data.wl_outputs` in `src/wayland.rs` for improved clarity and idiomatic iteration.
* In trait implementations for `Dispatch`, clarified parameter usage and type annotations for better readability and maintainability. [[1]](diffhunk://#diff-4f5c03d782af2d2b4e7bee98ac0e8c6cb2d68658b86bcc27fdf1e8107fb37423L50-R52) [[2]](diffhunk://#diff-4f5c03d782af2d2b4e7bee98ac0e8c6cb2d68658b86bcc27fdf1e8107fb37423L69-R71)
* Made the `use MouseButtons::*` import more explicit by listing individual variants, improving code clarity.